### PR TITLE
Tradeskill can return multiple valid values

### DIFF
--- a/Modules/Profession.lua
+++ b/Modules/Profession.lua
@@ -160,7 +160,7 @@ function Profession:UpdateProfession()
 	local trackingProfession = GT.DBCharacter:ProfessionExists(characterName, profession.professionName)
 
 	local _, kind = GetTradeSkillInfo(1)
-	if kind == nil or (kind ~= 'header' and kind ~= 'optimal') then
+	if kind == nil or (kind ~= 'header' and kind ~= 'trivial' and kind ~= 'easy' and kind ~= 'medium' and kind ~= 'optimal' and kind ~= 'difficult') then
 		-- GT.Log:Warn('Profession_UpdateProfession_UnexpectedHeader', Text:ToString(kind))
 		return
 	end


### PR DESCRIPTION
The function returned when a tradeskill is present, but was not 'optimal' (yellow) for the player. This causes an exit of Scanning enchanting.